### PR TITLE
multiple advisor apply

### DIFF
--- a/src/main/java/us/codecraft/tinyioc/aop/AspectJAwareAdvisorAutoProxyCreator.java
+++ b/src/main/java/us/codecraft/tinyioc/aop/AspectJAwareAdvisorAutoProxyCreator.java
@@ -38,7 +38,8 @@ public class AspectJAwareAdvisorAutoProxyCreator implements BeanPostProcessor, B
 				TargetSource targetSource = new TargetSource(bean, bean.getClass(), bean.getClass().getInterfaces());
 				advisedSupport.setTargetSource(targetSource);
 
-				return advisedSupport.getProxy();
+				//return advisedSupport.getProxy();
+				bean = advisedSupport.getProxy();
 			}
 		}
 		return bean;


### PR DESCRIPTION
相关文件：AOP相关的AspectJAwareAdvisorAutoProxyCreator类，源码第41行
修改内容：
`//return advisedSupport.getProxy();`
`bean=advisedSupport.getProxy();`
原先的实现初次匹配生成动态代理之后直接返回了，为便于拓展，修改为循环apply，便于多个Advisor增强；